### PR TITLE
Fix dockerfile so build will complete

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get --no-install-recommends install -y  \
 # imagemagick
      fuse libfuse2 \
 # fonts
-    fonts-noto \
+    fonts-noto
 
 RUN apt-get remove fonts-noto-color-emoji
 # python packages


### PR DESCRIPTION
Removed extra backslash (`\`) that was preventing the docker container build from completing successfully.
Extra backslash causes build step 5/15 to error:
```
1.615 Reading package lists...
2.209 Building dependency tree...
2.363 Reading state information...
2.369 E: Unable to locate package RUN
2.369 E: Unable to locate package apt-get
2.369 E: Unable to locate package remove
```
When removed, the container build process completes successfully. 😸